### PR TITLE
[Trello-aPQm5m4w] Added suppoer for HAL-JSON options for inline/body fields 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.angorasix</groupId>
   <artifactId>commons.core</artifactId>
-  <version>0.2.9</version>
+  <version>0.2.10</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/src/main/kotlin/com/angorasix/commons/domain/inputs/RequiredInput.kt
+++ b/src/main/kotlin/com/angorasix/commons/domain/inputs/RequiredInput.kt
@@ -1,0 +1,36 @@
+package com.angorasix.commons.domain.inputs
+
+/**
+ * <p>
+ *     Similar to the HAL-FORM output, but to be transmitted inside the response body,
+ *     at least until Spring provides support for defining options dynamically:
+ *     https://docs.spring.io/spring-hateoas/docs/current/reference/html/#mediatypes.hal-forms.options.
+ * </p>
+ *
+ * @author rozagerardo
+ */
+data class InlineFieldSpec(
+    val name: String, // key for the UI to show the label appropriately
+    val type: FieldSpec,
+    val options: InlineFieldOptions? = null,
+) {
+    constructor(name: String, type: FieldSpec, options: List<OptionSpec>) : this(
+        name,
+        type,
+        InlineFieldOptions(emptyList(), options),
+    )
+}
+
+data class InlineFieldOptions(
+    val selectedValues: List<String>,
+    val inline: List<OptionSpec>,
+)
+
+data class OptionSpec(
+    val value: String,
+    val prompt: String, // key for the UI to show the label appropriately
+)
+
+enum class FieldSpec(val value: String) {
+    TEXT("text"), SELECT("select"), DATE("date"), TIME("time"), DATETIME("datetime")
+}

--- a/src/main/kotlin/com/angorasix/commons/presentation/dto/InlineFieldSpecDto.kt
+++ b/src/main/kotlin/com/angorasix/commons/presentation/dto/InlineFieldSpecDto.kt
@@ -1,0 +1,40 @@
+package com.angorasix.commons.presentation.dto
+
+import com.angorasix.commons.domain.inputs.FieldSpec
+import com.angorasix.commons.domain.inputs.InlineFieldOptions
+import com.angorasix.commons.domain.inputs.InlineFieldSpec
+import com.angorasix.commons.domain.inputs.OptionSpec
+
+/**
+ * <p>
+ *     Similar to the HAL-FORM output, but to be transmitted inside the response body,
+ *     at least until Spring provides support for defining options dynamically:
+ *     https://docs.spring.io/spring-hateoas/docs/current/reference/html/#mediatypes.hal-forms.options.
+ * </p>
+ *
+ * @author rozagerardo
+ */
+data class InlineFieldSpecDto(
+    val name: String, // key for the UI to show the label appropriately
+    val type: FieldSpec,
+    val options: InlineFieldOptionsDto?,
+)
+
+data class InlineFieldOptionsDto(
+    val selectedValues: List<String>,
+    val inline: List<OptionSpecDto>,
+)
+
+data class OptionSpecDto(
+    val prompt: String, // key for the UI to show the label appropriately
+    val value: String,
+)
+
+fun InlineFieldSpec.convertToDto(): InlineFieldSpecDto =
+    InlineFieldSpecDto(name, type, options?.convertToDto())
+
+fun InlineFieldOptions.convertToDto(): InlineFieldOptionsDto =
+    InlineFieldOptionsDto(selectedValues, inline.map { it.convertToDto() })
+
+fun OptionSpec.convertToDto(): OptionSpecDto =
+    OptionSpecDto(prompt, value)


### PR DESCRIPTION
(dynamic options with Spring HATEOAS is not yet supported: #1695